### PR TITLE
snap: update to core22

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ description: |
   30-odd search results per page. The default interface is carefully designed 
   to use minimum space without sacrificing readability.
   ddgr isn't affiliated to DuckDuckGo in any way..
-base: core20
+base: core22
 
 grade: stable
 confinement: strict
@@ -46,54 +46,40 @@ parts:
     stage-packages:
       - python3
       - python3-requests
-    filesets:
-      cruft_compilers_and_debuggers:
-        - -usr/bin/pdb3*
-      cruft_debhelper:
-        - -usr/bin/dh_*
-        - -usr/share/debhelper
-        - -usr/share/dh-python
-        - -usr/share/perl5/Debian
-      cruft_docs:
-        - -usr/share/doc
-        - -usr/share/doc-base
-      cruft_lintian:
-        - -usr/share/lintian/overrides
-      cruft_man_pages:
-        - -usr/share/man
-        - -share/man
-      cruft_meta:
-        - -usr/share/applications
-        - -usr/share/pixmaps
-      cruft_python_2to3:
-        - -usr/bin/2to3*
-        - -usr/lib/python*/lib2to3
-      cruft_python_idle:
-        - -usr/lib/python*/idlelib
-        - -usr/lib/python*/tkinter
-      cruft_python_pip:
-        - -lib/python*/site-packages/pip
-      cruft_python_setuptools:
-        - -lib/python*/site-packages/setuptools*
-      cruft_python_tests:
-        - -lib/python*/site-packages/tests
-      cruft_python_venv:
-        - -usr/lib/python*/venv
-      cruft_python_wheel:
-        - -lib/python*/site-packages/wheel*
-      cruft_x11:
-        - -usr/share/X11/XErrorDB
     prime:
-      - $cruft_compilers_and_debuggers
-      - $cruft_debhelper
-      - $cruft_docs
-      - $cruft_lintian
-      - $cruft_man_pages
-      - $cruft_python_2to3
-      - $cruft_python_idle
-      - $cruft_python_pip
-      - $cruft_python_setuptools
-      - $cruft_python_tests
-      - $cruft_python_venv
-      - $cruft_python_wheel
-      - $cruft_x11
+      # compilers and debuggers
+      - -usr/bin/pdb3*
+      # debhelper
+      - -usr/bin/dh_*
+      - -usr/share/debhelper
+      - -usr/share/dh-python
+      - -usr/share/perl5/Debian
+      # docs
+      - -usr/share/doc
+      - -usr/share/doc-base
+      # lintian
+      - -usr/share/lintian/overrides
+      # man pages
+      - -usr/share/man
+      - -share/man
+      # meta
+      - -usr/share/applications
+      - -usr/share/pixmaps
+      # python 2to3
+      - -usr/bin/2to3*
+      - -usr/lib/python*/lib2to3
+      # python idle
+      - -usr/lib/python*/idlelib
+      - -usr/lib/python*/tkinter
+      # python pip
+      - -lib/python*/site-packages/pip
+      # python setuptools
+      - -lib/python*/site-packages/setuptools*
+      # python tests
+      - -lib/python*/site-packages/tests
+      # python venv
+      - -usr/lib/python*/venv
+      # python wheel
+      - -lib/python*/site-packages/wheel*
+      # x11
+      - -usr/share/X11/XErrorDB


### PR DESCRIPTION
Update to `core22`.
Filesets are not currently supported in `core22`, so they were removed from this `snapcraft.yaml`.